### PR TITLE
Request clone fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+phpunit.xml
+vendor

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,41 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in('src')
+    ->in('test');
+
+$config = Symfony\CS\Config\Config::create();
+$config->level(null);
+$config->fixers(
+    array(
+        'braces',
+        'duplicate_semicolon',
+        'elseif',
+        'empty_return',
+        'encoding',
+        'eof_ending',
+        'function_call_space',
+        'function_declaration',
+        'indentation',
+        'join_function',
+        'line_after_namespace',
+        'linefeed',
+        'lowercase_keywords',
+        'parenthesis',
+        'multiple_use',
+        'method_argument_space',
+        'object_operator',
+        'php_closing_tag',
+        'remove_lines_between_uses',
+        'short_array_syntax',
+        'short_tag',
+        'standardize_not_equal',
+        'trailing_spaces',
+        'unused_use',
+        'visibility',
+        'whitespacy_lines',
+    )
+);
+$config->finder($finder);
+
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 5.4
     - php: 5.5
     - php: 5.6
     - php: 7

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 matrix:
   fast_finish: true
   include:
+    - php: 5.4
     - php: 5.5
     - php: 5.6
     - php: 7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: false
+
+language: php
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.5
+    - php: 5.6
+    - php: 7
+    - php: hhvm
+  allow_failures:
+    - php: hhvm
+
+before_install:
+  - composer self-update
+
+install:
+  - travis_retry composer install --no-interaction --ignore-platform-reqs
+
+script:
+  - ./vendor/bin/phpunit

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2013 Diablo Media
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,28 @@
         {
             "name": "Ari Pringle",
             "email": "ari@diablomedia.com",
-            "homepage": "http://diablomedia.com/"
+            "homepage": "https://diablomedia.com"
+        },
+        {
+            "name": "Jay Klehr",
+            "email": "jay@diablomedia.com",
+            "homepage": "https://diablomedia.com"
         }
     ],
     "homepage": "http://github.com/diablomedia/oauth2-server-zendhttp-bridge",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0",
+        "zendframework/zend-http": "^2.0",
+        "bshaffer/oauth2-server-php": "^1.0"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^1.7",
+        "phpunit/PHPUnit": "^4.0"
     },
     "autoload": {
         "psr-0": {"OAuth2\\ZendHttpPhpEnvironmentBridge": "src/"}
+    },
+    "autoload-dev": {
+        "psr-0": {"OAuth2Test\\ZendHttpPhpEnvironmentBridge": "test/"}
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "homepage": "http://github.com/diablomedia/oauth2-server-zendhttp-bridge",
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "zendframework/zend-http": "^2.0",
         "bshaffer/oauth2-server-php": "^1.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./test/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="oauth2-server-zendhttp-bridge Test Suite">
+            <directory>./test/</directory>
+        </testsuite>
+    </testsuites>
+
+    <groups>
+        <exclude>
+            <group>disable</group>
+        </exclude>
+    </groups>
+
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+
+    <php>
+        <ini name="date.timezone" value="UTC"/>
+    </php>
+</phpunit>

--- a/src/OAuth2/ZendHttpPhpEnvironmentBridge/Request.php
+++ b/src/OAuth2/ZendHttpPhpEnvironmentBridge/Request.php
@@ -39,6 +39,18 @@ class Request extends BaseRequest implements RequestInterface
 
     public static function createFromRequest(BaseRequest $request)
     {
-        return new static($request->getQuery(), $request->getPost(), array(), $request->getCookie(), $request->getFiles(), $request->getServer(), $request->getContent());
+        $new = static::fromString($request->toString());
+        $new->setQuery($request->getQuery());
+        $new->setPost($request->getPost());
+        $new->setCookies($request->getCookie());
+        $new->setFiles($request->getFiles());
+        $new->setServer($request->getServer());
+        $new->setContent($request->getContent());
+        $new->setEnv($request->getEnv());
+
+        $headers = $request->getHeaders();
+        $new->setHeaders($headers);
+
+        return $new;
     }
 }

--- a/src/OAuth2/ZendHttpPhpEnvironmentBridge/Response.php
+++ b/src/OAuth2/ZendHttpPhpEnvironmentBridge/Response.php
@@ -30,11 +30,11 @@ class Response extends BaseResponse implements ResponseInterface
         $this->setStatusCode($statusCode);
         $this->addParameters(
             array_filter(
-                array(
+                [
                     'error'             => $name,
                     'error_description' => $description,
                     'error_uri'         => $uri,
-                )
+                ]
             )
         );
     }
@@ -44,13 +44,13 @@ class Response extends BaseResponse implements ResponseInterface
         $this->setStatusCode($statusCode);
         $this->addParameters(
             array_filter(
-                array(
+                [
                     'error'             => $error,
                     'error_description' => $errorDescription,
                     'error_uri'         => $errorUri,
-                )
+                ]
             )
         );
-        $this->addHttpHeaders(array('Location' => $url));
+        $this->addHttpHeaders(['Location' => $url]);
     }
 }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace OAuth2Test\ZendHttpPhpEnvironmentBridge;
+
+use Zend\Http\PhpEnvironment\Request as BaseRequest;
+use OAuth2\ZendHttpPhpEnvironmentBridge\Request;
+use PHPUnit_Framework_TestCase;
+
+class RequestTest extends PHPUnit_Framework_TestCase
+{
+    public function setup()
+    {
+        $this->baseRequest = BaseRequest::fromString("GET /index.php?test=true HTTP/1.1\r\n\r\nSome Content");
+        $serverVars = $this->baseRequest->getServer();
+        $serverVars['REQUEST_METHOD'] = 'GET';
+    }
+
+    public function testCreateFromRequestReturnsRequestObject()
+    {
+        $request = Request::createFromRequest($this->baseRequest);
+
+        $this->assertInstanceOf('OAuth2\ZendHttpPhpEnvironmentBridge\Request', $request);
+    }
+
+    public function testRequestHasQueryMethod()
+    {
+        $request = Request::createFromRequest($this->baseRequest);
+
+        $this->assertEquals('true', $request->query('test'));
+    }
+
+    public function testRequestHasServerMethod()
+    {
+        $request = Request::createFromRequest($this->baseRequest);
+
+        $this->assertEquals('GET', $request->server('REQUEST_METHOD'));
+    }
+
+    public function testRequestHasRequestMethodAndReturnsPostVars()
+    {
+        $baseRequest = BaseRequest::fromString("POST /index.php HTTP/1.1\r\n\r\ntesting=true");
+        $serverVars = $baseRequest->getServer();
+        $serverVars['REQUEST_METHOD'] = 'POST';
+
+        $postVars = $baseRequest->getPost();
+        $postVars['testing'] = 'true';
+
+        $request = Request::createFromRequest($baseRequest);
+
+        $this->assertEquals('true', $request->request('testing'));
+    }
+
+    public function testRequestHasHeadersMethod()
+    {
+        $baseRequest = BaseRequest::fromString("GET /index.php HTTP/1.1\r\nAccept: */*\r\n\r\nSome Content");
+
+        $request = Request::createFromRequest($baseRequest);
+
+        $this->assertEquals('Accept: */*', $request->headers('Accept'));
+    }
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+/*
+ * Set error reporting to the level to which Zend Framework code must comply.
+ */
+error_reporting(E_ALL | E_STRICT);
+
+/**
+ * Setup autoloading
+ */
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
When trying to “fake” a request sent to this method, noticed that it wasn’t actually taking the modified request (and was just building one from PHP globals).  This builds a new request from the string version
of the passed in one, then sets all the parameter containers to match the original container’s values.

Also adding tests, travis config, some other dependencies, php_cs config file.

Most of the supplemental changes (phpunit, travis, php_cs, etc...) were taken from the Zend HTTP repo with the necessary changes (which is why minimum version was bumped to 5.4 (php_cs has short_array_syntax configured)).